### PR TITLE
feat(shop): switch all buying CTAs to sales WhatsApp +52 55 4846 8190

### DIFF
--- a/src/components/commerce21/ProductComparison.tsx
+++ b/src/components/commerce21/ProductComparison.tsx
@@ -146,7 +146,7 @@ export function ProductComparison({ products, onClose, className = '' }: Product
                       <ArrowRight className="h-4 w-4" />
                     </Link>
                     <a
-                      href="https://wa.me/523222787690"
+                      href="https://wa.me/525548468190"
                       className="inline-flex items-center justify-center gap-2 w-full px-4 py-2 rounded-lg border border-border text-foreground hover:bg-muted transition-colors text-sm"
                     >
                       Consultar
@@ -172,7 +172,7 @@ export function ProductComparison({ products, onClose, className = '' }: Product
             </p>
             <div className="flex gap-2">
               <a
-                href="https://wa.me/523222787690"
+                href="https://wa.me/525548468190"
                 className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-green-600 text-white hover:bg-green-700 transition-colors text-sm font-medium"
               >
                 Hablar con experto

--- a/src/components/commerce21/StickyMobileCTA.tsx
+++ b/src/components/commerce21/StickyMobileCTA.tsx
@@ -113,7 +113,7 @@ export function StickyMobileCTA({
         {/* CTA buttons row */}
         <div className="flex items-center gap-2">
           <a
-            href="tel:+523222787690"
+            href="tel:+525548468190"
             className="flex-shrink-0 inline-flex items-center justify-center gap-2 px-4 py-3 rounded-lg border border-border bg-background text-foreground font-medium hover:bg-muted transition-colors shadow-md"
             aria-label="Llamar"
           >

--- a/src/components/ui/FloatingWhatsApp.tsx
+++ b/src/components/ui/FloatingWhatsApp.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { MessageCircle } from 'lucide-react';
 
-const WHATSAPP_NUMBER = '523222787690';
+const WHATSAPP_NUMBER = '525548468190';
 const DEFAULT_MESSAGE = 'Hola, tengo una pregunta sobre sus productos de Pilates.';
 
 interface FloatingWhatsAppProps {

--- a/src/lib/shop/whatsapp.ts
+++ b/src/lib/shop/whatsapp.ts
@@ -1,7 +1,7 @@
 import type { Product } from './types';
 import { getOrigin } from '@/lib/seo';
 
-export const WHATSAPP_PHONE = '523222787690';
+export const WHATSAPP_PHONE = '525548468190';
 
 /**
  * WhatsApp deep link with a pre-filled message referencing the product

--- a/src/pages/CamaDePilatesEnVenta.tsx
+++ b/src/pages/CamaDePilatesEnVenta.tsx
@@ -238,7 +238,7 @@ const CamaDePilatesEnVenta: React.FC = () => {
                 Ver packs para estudio
               </Link>
               <a
-                href="https://wa.me/523222787690"
+                href="https://wa.me/525548468190"
                 className="inline-flex items-center justify-center px-10 py-5 border border-white/20 text-white rounded-full text-xs font-bold uppercase tracking-[0.2em] hover:bg-white/10 transition-all"
               >
                 Cotizar por WhatsApp

--- a/src/pages/Compare.tsx
+++ b/src/pages/Compare.tsx
@@ -153,7 +153,7 @@ const Compare = () => {
                 Ver y comprar
               </Link>
               <a
-                href="https://wa.me/523222787690"
+                href="https://wa.me/525548468190"
                 className="mt-3 inline-flex items-center justify-center w-full px-8 py-5 border border-[#2A2624]/20 text-[#2A2624] rounded-full text-xs font-bold uppercase tracking-[0.2em] hover:bg-white transition-all"
               >
                 Cotizar por WhatsApp
@@ -196,7 +196,7 @@ const Compare = () => {
                 Ver y comprar
               </Link>
               <a
-                href="https://wa.me/523222787690"
+                href="https://wa.me/525548468190"
                 className="mt-3 inline-flex items-center justify-center w-full px-8 py-5 border border-white/20 text-white rounded-full text-xs font-bold uppercase tracking-[0.2em] hover:bg-white/10 transition-all"
               >
                 Cotizar por WhatsApp

--- a/src/pages/PilatesReformerCDMX.tsx
+++ b/src/pages/PilatesReformerCDMX.tsx
@@ -256,7 +256,7 @@ const PilatesReformerCDMX: React.FC = () => {
                   Ver Tienda
                 </Link>
                 <a
-                  href="https://wa.me/523222787690?text=Hola,%20me%20interesa%20un%20reformer%20en%20CDMX"
+                  href="https://wa.me/525548468190?text=Hola,%20me%20interesa%20un%20reformer%20en%20CDMX"
                   className="inline-flex items-center gap-2 px-8 py-4 border border-[#2A2624] text-[#2A2624] rounded-full text-xs uppercase tracking-[0.2em] hover:bg-[#2A2624] hover:text-[#EAE8E4] transition-colors"
                 >
                   <Phone className="w-4 h-4" /> WhatsApp

--- a/src/pages/Product.tsx
+++ b/src/pages/Product.tsx
@@ -337,7 +337,7 @@ const ProductPage: React.FC = () => {
                   <a href={buyWhatsAppUrl} target="_blank" rel="noopener noreferrer" className="flex items-center justify-center gap-2 px-4 py-3 border border-[#2A2624]/20 rounded-full text-[10px] uppercase tracking-[0.2em] text-[#2A2624] hover:bg-[#2A2624] hover:text-[#EAE8E4] transition-colors">
                     WhatsApp
                   </a>
-                  <a href="tel:+523222787690" className="flex items-center justify-center gap-2 px-4 py-3 border border-[#2A2624]/20 rounded-full text-[10px] uppercase tracking-[0.2em] text-[#2A2624] hover:bg-[#2A2624] hover:text-[#EAE8E4] transition-colors">
+                  <a href="tel:+525548468190" className="flex items-center justify-center gap-2 px-4 py-3 border border-[#2A2624]/20 rounded-full text-[10px] uppercase tracking-[0.2em] text-[#2A2624] hover:bg-[#2A2624] hover:text-[#EAE8E4] transition-colors">
                     Llamar
                   </a>
                 </div>

--- a/src/pages/ReformersNew.tsx
+++ b/src/pages/ReformersNew.tsx
@@ -280,7 +280,7 @@ const ReformersNew: React.FC = () => {
               </p>
               <div className="mt-6 flex flex-wrap items-center gap-3">
                 <EnhancedButton asChild className="rounded-full bg-[#3E2723] text-white hover:bg-[#3E2723]/90">
-                  <a href="https://wa.me/523222787690">Cotizar por WhatsApp</a>
+                  <a href="https://wa.me/525548468190">Cotizar por WhatsApp</a>
                 </EnhancedButton>
                 <EnhancedButton asChild variant="outline" className="rounded-full border-[#2A2624]/20 bg-white/60">
                   <Link to="/compare">Comparar modelos</Link>
@@ -412,7 +412,7 @@ const ReformersNew: React.FC = () => {
                         <Link to="/compare">Ir a comparar</Link>
                       </EnhancedButton>
                       <EnhancedButton asChild variant="outline" className="rounded-full border-[#2A2624]/20 bg-white/60">
-                        <a href="https://wa.me/523222787690" className="inline-flex items-center gap-2">Cotizar <ArrowRight className="h-4 w-4" /></a>
+                        <a href="https://wa.me/525548468190" className="inline-flex items-center gap-2">Cotizar <ArrowRight className="h-4 w-4" /></a>
                       </EnhancedButton>
                     </div>
                   </div>

--- a/src/pages/ReformersUsed.tsx
+++ b/src/pages/ReformersUsed.tsx
@@ -42,7 +42,7 @@ const ReformersUsed: React.FC = () => {
           <div className="flex flex-wrap items-center gap-2">
             <Link to="/reformers/nuevas" className="text-xs uppercase tracking-widest text-[#3E2723] hover:opacity-70">Ver nuevas</Link>
             <span className="text-[#2A2624]/20">•</span>
-            <a href="https://wa.me/523222787690" className="text-xs uppercase tracking-widest text-[#3E2723] hover:opacity-70">Pedir checklist por WhatsApp</a>
+            <a href="https://wa.me/525548468190" className="text-xs uppercase tracking-widest text-[#3E2723] hover:opacity-70">Pedir checklist por WhatsApp</a>
           </div>
         </div>
 
@@ -85,7 +85,7 @@ const ReformersUsed: React.FC = () => {
               <div className="rounded-2xl border border-[#2A2624]/10 bg-white/60 p-6">
                 <div className="text-xs uppercase tracking-widest text-[#5D5550]">¿Quieres vender una usada?</div>
                 <p className="mt-2 text-sm text-[#2A2624]">Escríbenos por WhatsApp con fotos y ciudad. Te decimos cómo listarla y qué información incluir.</p>
-                <a href="https://wa.me/523222787690" className="mt-4 block rounded-full bg-[#3E2723] text-white px-5 py-2 text-xs uppercase tracking-widest text-center hover:opacity-90">Contactar</a>
+                <a href="https://wa.me/525548468190" className="mt-4 block rounded-full bg-[#3E2723] text-white px-5 py-2 text-xs uppercase tracking-widest text-center hover:opacity-90">Contactar</a>
               </div>
 
               <div className="rounded-2xl border border-[#2A2624]/10 bg-white/60 p-6">

--- a/src/pages/Shop.tsx
+++ b/src/pages/Shop.tsx
@@ -218,8 +218,8 @@ const Shop: React.FC = () => {
               Shop<span className="text-[#EB4C42]">.</span>
             </p>
             <div className="flex items-center gap-4 text-[10px] font-bold uppercase tracking-[0.2em] opacity-60">
-              <a href="https://wa.me/523222787690" className="hover:text-[#EB4C42] transition-colors">WhatsApp</a>
-              <a href="tel:+523222787690" className="hover:text-[#EB4C42] transition-colors">Llamar</a>
+              <a href="https://wa.me/525548468190" className="hover:text-[#EB4C42] transition-colors">WhatsApp</a>
+              <a href="tel:+525548468190" className="hover:text-[#EB4C42] transition-colors">Llamar</a>
               <div className="hidden sm:block text-[#5D5550]">
                 <Link to="/compare" className="hover:text-[#EB4C42] transition-colors">Comparar Modelos</Link>
               </div>

--- a/src/pages/StudioPack.tsx
+++ b/src/pages/StudioPack.tsx
@@ -193,7 +193,7 @@ const StudioPack: React.FC = () => {
 
             <div className="mt-8 pt-8 border-t border-white/10 text-center">
               <p className="text-xs text-white/40 mb-2">Prefer direct contact?</p>
-              <a href="https://wa.me/523222787690" className="text-sm hover:text-white transition-colors border-b border-white/20 pb-1">Chat on WhatsApp</a>
+              <a href="https://wa.me/525548468190" className="text-sm hover:text-white transition-colors border-b border-white/20 pb-1">Chat on WhatsApp</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

All purchase/quote CTAs now contact the dedicated sales WhatsApp **+52 55 4846 8190** (`wa.me/525548468190`). Support, navigation, and certification contacts keep the existing number.

## Changes

- `WHATSAPP_PHONE` in the shared buy-link helper (`src/lib/shop/whatsapp.ts`) — covers the product page buy button, sticky mobile CTA, quick-view modal, and featured product card, all with the product-specific pre-filled message
- Floating WhatsApp product-question bubble
- Sales page CTAs: product comparison tables, `/compare`, `cama-de-pilates-en-venta`, `reformers-nuevos` (cotizar), `reformers-usados`, `pilates-reformer-cdmx`, studio pack, and the shop contact link
- The "Llamar" call buttons inside the product buy flow (desktop + mobile sticky) now dial the same sales number

## Testing

- `npm run build` passes
- No remaining `523222787690` references in buying flows (verified by grep); remaining references are support/nav/certification only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018oXZE1VWVYFKUYfYnLK1b1

---
_Generated by [Claude Code](https://claude.ai/code/session_018oXZE1VWVYFKUYfYnLK1b1)_