### PR TITLE
feat(contact): move all remaining WhatsApp contacts to +52 55 4846 8190

### DIFF
--- a/src/components/layout/EdelweissNav.tsx
+++ b/src/components/layout/EdelweissNav.tsx
@@ -262,7 +262,7 @@ const EdelweissNav: React.FC<EdelweissNavProps> = ({ darkBackground = false }) =
                   <a href="mailto:hello@camadepilates.com" className="hover:text-[#F5F4F1]/70 transition-colors">
                     hello@camadepilates.com
                   </a>
-                  <a href="https://wa.me/523222787690" className="hover:text-[#F5F4F1]/70 transition-colors">
+                  <a href="https://wa.me/525548468190" className="hover:text-[#F5F4F1]/70 transition-colors">
                     WhatsApp
                   </a>
                 </div>

--- a/src/components/layout/LuxuryLayout.tsx
+++ b/src/components/layout/LuxuryLayout.tsx
@@ -42,7 +42,7 @@ const LuxuryLayout = ({ children, className = "", noPadding = false, headerTheme
                             <h4 className="text-xs uppercase tracking-[0.2em] mb-6 text-white/40">Contacto</h4>
                             <ul className="space-y-4 text-sm font-light text-white/80">
                                 <li><a href="mailto:hello@camadepilates.com" className="hover:text-white transition-colors">hello@camadepilates.com</a></li>
-                                <li><a href="https://wa.me/523222787690" className="hover:text-white transition-colors">Soporte WhatsApp</a></li>
+                                <li><a href="https://wa.me/525548468190" className="hover:text-white transition-colors">Soporte WhatsApp</a></li>
                             </ul>
                         </div>
                     </div>

--- a/src/pages/CertificacionPilates.tsx
+++ b/src/pages/CertificacionPilates.tsx
@@ -22,7 +22,7 @@ const CITIES = [
   { key: 'queretaro', name: 'Querétaro', kw: ['certificación pilates querétaro'] },
 ];
 
-const PRIMARY_WHATSAPP_BASE = 'https://wa.me/523222787690?text=';
+const PRIMARY_WHATSAPP_BASE = 'https://wa.me/525548468190?text=';
 const PRIMARY_WHATSAPP = `${PRIMARY_WHATSAPP_BASE}${encodeURIComponent('Hola, quiero inscribirme a la certificación STOTT PILATES® en CDMX')}`;
 
 const FEATURED = STOTT_COURSES.find(c => c.featured) || STOTT_COURSES[0];

--- a/src/pages/CertificacionPilatesCity.tsx
+++ b/src/pages/CertificacionPilatesCity.tsx
@@ -54,7 +54,7 @@ const CITY_DATA: Record<CityKey, { name: string; variants: string[] }> = {
   }
 };
 
-const PRIMARY_WHATSAPP = 'https://wa.me/523222787690?text=';
+const PRIMARY_WHATSAPP = 'https://wa.me/525548468190?text=';
 
 const FEATURED = STOTT_COURSES.find(c => c.featured) || STOTT_COURSES[0];
 

--- a/src/pages/Support.tsx
+++ b/src/pages/Support.tsx
@@ -30,7 +30,7 @@ const Support: React.FC = () => {
             </p>
 
             <div className="flex flex-col gap-6">
-              <a href="https://wa.me/523222787690" className="group flex items-center gap-4 p-6 border border-[#2A2624]/10 rounded-sm hover:bg-white transition-colors">
+              <a href="https://wa.me/525548468190" className="group flex items-center gap-4 p-6 border border-[#2A2624]/10 rounded-sm hover:bg-white transition-colors">
                 <div className="w-12 h-12 rounded-full bg-[#2A2624] flex items-center justify-center text-[#EAE8E4] group-hover:bg-[#3E2723] transition-colors">
                   <MessageCircle className="w-6 h-6" />
                 </div>


### PR DESCRIPTION
## Summary

Unifies every WhatsApp contact on the site to **+52 55 4846 8190**. Combined with #9, all `wa.me` links (buying, support, floating bubble, nav, footer, certification enrollment) now use the same number — zero references to the previous number remain in `src`.

## Changes

- Footer "Soporte WhatsApp" (`LuxuryLayout`)
- Nav contact link (`EdelweissNav`)
- Support page contact card
- Certification enrollment CTAs (`/certificacion-pilates` and city pages, including the STOTT premium program buttons which inherit the base URL)

## Testing

- `npm run build` passes
- `grep 523222787690 src` → 0 matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018oXZE1VWVYFKUYfYnLK1b1

---
_Generated by [Claude Code](https://claude.ai/code/session_018oXZE1VWVYFKUYfYnLK1b1)_