### PR TITLE
fix(ci): support multiline blog changes

### DIFF
--- a/.github/workflows/register-placeholders.yml
+++ b/.github/workflows/register-placeholders.yml
@@ -49,7 +49,11 @@ jobs:
             AFTER=$(git rev-parse HEAD)
           fi
           CHANGED=$(git diff --name-only "$BEFORE" "$AFTER" | grep '^src/content/blog/.*\.md$' || true)
-          echo "changed=$CHANGED" >> $GITHUB_OUTPUT
+          {
+            echo 'changed<<EOF_CHANGED'
+            printf '%s\n' "$CHANGED"
+            echo 'EOF_CHANGED'
+          } >> "$GITHUB_OUTPUT"
 
       - name: "Register placeholders (push: changed only)"
         if: github.event_name == 'push' && steps.changed.outputs.changed != ''


### PR DESCRIPTION
## Summary
- emit changed blog paths with GitHub Actions multiline output syntax
- prevent placeholder registration from failing when a push changes multiple posts

## Validation
- parsed workflow YAML
- simulated multiline output payload
- GSC analyzer lint/tests passed (8 tests)
- source TypeScript and correctness lint gates passed
- production build and static prerender passed