### PR TITLE
fix(growth): support Search Console ADC auth

### DIFF
--- a/scripts/gsc-opportunities.test.ts
+++ b/scripts/gsc-opportunities.test.ts
@@ -3,11 +3,14 @@
 import {
   analyzeGscOpportunities,
   createServiceAccountJwt,
-  loadServiceAccount,
+  loadGoogleCredentials,
   requireAnalyzerConfig,
   scoreOpportunities,
 } from "./gsc-opportunities.ts";
-import type { ServiceAccountCredentials } from "./gsc-opportunities.ts";
+import type {
+  AuthorizedUserCredentials,
+  ServiceAccountCredentials,
+} from "./gsc-opportunities.ts";
 
 function assert(
   condition: unknown,
@@ -128,17 +131,17 @@ Deno.test("requireAnalyzerConfig fails loudly for missing configuration", () => 
   );
 });
 
-Deno.test("loadServiceAccount fails without exposing a missing path", async () => {
+Deno.test("loadGoogleCredentials fails without exposing a missing path", async () => {
   const missingPath = "/private/example/service-account.json";
   await assertRejects(
     () =>
-      loadServiceAccount(missingPath, () => {
+      loadGoogleCredentials(missingPath, () => {
         throw new Deno.errors.NotFound();
       }),
-    "Unable to read Google service account credentials file",
+    "Unable to read Google credentials file",
   );
   try {
-    await loadServiceAccount(missingPath, () => {
+    await loadGoogleCredentials(missingPath, () => {
       throw new Deno.errors.NotFound();
     });
   } catch (error) {
@@ -147,25 +150,28 @@ Deno.test("loadServiceAccount fails without exposing a missing path", async () =
   }
 });
 
-Deno.test("loadServiceAccount rejects malformed credentials", async () => {
+Deno.test("loadGoogleCredentials rejects malformed credentials", async () => {
   await assertRejects(
-    () => loadServiceAccount("unused", () => Promise.resolve("not json")),
+    () => loadGoogleCredentials("unused", () => Promise.resolve("not json")),
     "must be valid JSON",
   );
   await assertRejects(
     () =>
-      loadServiceAccount(
+      loadGoogleCredentials(
         "unused",
         () =>
           Promise.resolve(
-            JSON.stringify({ client_email: "reader@example.com" }),
+            JSON.stringify({
+              type: "service_account",
+              client_email: "reader@example.com",
+            }),
           ),
       ),
     "private_key",
   );
   await assertRejects(
     () =>
-      loadServiceAccount(
+      loadGoogleCredentials(
         "unused",
         () =>
           Promise.resolve(
@@ -178,6 +184,21 @@ Deno.test("loadServiceAccount rejects malformed credentials", async () => {
           ),
       ),
     "PKCS#8 PEM key",
+  );
+  await assertRejects(
+    () =>
+      loadGoogleCredentials(
+        "unused",
+        () =>
+          Promise.resolve(
+            JSON.stringify({
+              type: "authorized_user",
+              client_id: "client-id",
+              client_secret: "client-secret",
+            }),
+          ),
+      ),
+    "refresh_token",
   );
 });
 
@@ -288,6 +309,53 @@ Deno.test("analyzer exchanges OAuth JWT and queries Search Analytics", async () 
   assertEquals(
     opportunities.map((opportunity) => opportunity.query),
     ["first", "same score"],
+  );
+});
+
+Deno.test("analyzer refreshes authorized user ADC with its quota project", async () => {
+  const credentials: AuthorizedUserCredentials = {
+    type: "authorized_user",
+    client_id: "test-client-id",
+    client_secret: "test-client-secret",
+    refresh_token: "test-refresh-token",
+    quota_project_id: "test-quota-project",
+  };
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fetcher = ((input: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(input), init });
+    if (calls.length === 1) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ access_token: "test-access-token" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify({ rows: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  }) as typeof fetch;
+
+  await analyzeGscOpportunities(
+    analyzerEnvironment(),
+    () => Promise.resolve(JSON.stringify(credentials)),
+    fetcher,
+    new Date("2024-02-29T12:00:00.000Z"),
+  );
+
+  assertEquals(calls.length, 2);
+  assertEquals(calls[0].url, "https://oauth2.googleapis.com/token");
+  const tokenBody = new URLSearchParams(String(calls[0].init?.body));
+  assertEquals(tokenBody.get("grant_type"), "refresh_token");
+  assertEquals(tokenBody.get("client_id"), credentials.client_id);
+  assertEquals(tokenBody.get("client_secret"), credentials.client_secret);
+  assertEquals(tokenBody.get("refresh_token"), credentials.refresh_token);
+  assertEquals(
+    new Headers(calls[1].init?.headers).get("x-goog-user-project"),
+    credentials.quota_project_id,
   );
 });
 

--- a/scripts/gsc-opportunities.ts
+++ b/scripts/gsc-opportunities.ts
@@ -7,6 +7,18 @@ export interface ServiceAccountCredentials {
   token_uri: string;
 }
 
+export interface AuthorizedUserCredentials {
+  type: "authorized_user";
+  client_id: string;
+  client_secret: string;
+  refresh_token: string;
+  quota_project_id?: string;
+}
+
+export type GoogleCredentials =
+  | ServiceAccountCredentials
+  | AuthorizedUserCredentials;
+
 interface SearchAnalyticsRow {
   keys: string[];
   clicks: number;
@@ -70,68 +82,91 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-export async function loadServiceAccount(
+export async function loadGoogleCredentials(
   credentialsPath: string,
   readTextFile: ReadTextFile = Deno.readTextFile,
-): Promise<ServiceAccountCredentials> {
+): Promise<GoogleCredentials> {
   let raw: string;
   try {
     raw = await readTextFile(credentialsPath);
   } catch {
-    throw new Error("Unable to read Google service account credentials file");
+    throw new Error("Unable to read Google credentials file");
   }
 
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
   } catch {
-    throw new Error("Google service account credentials must be valid JSON");
+    throw new Error("Google credentials must be valid JSON");
   }
   if (!isRecord(parsed)) {
-    throw new Error("Google service account credentials must be a JSON object");
+    throw new Error("Google credentials must be a JSON object");
   }
 
   const requiredString = (field: string): string => {
     const value = parsed[field];
     if (typeof value !== "string" || !value.trim()) {
       throw new Error(
-        `Google service account credentials are missing required field: ${field}`,
+        `Google credentials are missing required field: ${field}`,
       );
     }
     return value;
   };
-  const clientEmail = requiredString("client_email");
-  const privateKey = requiredString("private_key");
-  const tokenUri = requiredString("token_uri");
-  if (parsed.type !== "service_account") {
-    throw new Error(
-      "Google service account credentials have invalid type",
-    );
-  }
-  if (
-    !privateKey.includes("-----BEGIN PRIVATE KEY-----") ||
-    !privateKey.includes("-----END PRIVATE KEY-----")
-  ) {
-    throw new Error(
-      "Google service account private_key is not a PKCS#8 PEM key",
-    );
-  }
-  let parsedTokenUri: URL;
-  try {
-    parsedTokenUri = new URL(tokenUri);
-  } catch {
-    throw new Error("Google service account token_uri must be a valid URL");
-  }
-  if (parsedTokenUri.protocol !== "https:") {
-    throw new Error("Google service account token_uri must use HTTPS");
+
+  if (parsed.type === "service_account") {
+    const clientEmail = requiredString("client_email");
+    const privateKey = requiredString("private_key");
+    const tokenUri = requiredString("token_uri");
+    if (
+      !privateKey.includes("-----BEGIN PRIVATE KEY-----") ||
+      !privateKey.includes("-----END PRIVATE KEY-----")
+    ) {
+      throw new Error(
+        "Google service account private_key is not a PKCS#8 PEM key",
+      );
+    }
+    let parsedTokenUri: URL;
+    try {
+      parsedTokenUri = new URL(tokenUri);
+    } catch {
+      throw new Error("Google service account token_uri must be a valid URL");
+    }
+    if (parsedTokenUri.protocol !== "https:") {
+      throw new Error("Google service account token_uri must use HTTPS");
+    }
+
+    return {
+      type: "service_account",
+      client_email: clientEmail,
+      private_key: privateKey,
+      token_uri: tokenUri,
+    };
   }
 
-  return {
-    type: "service_account",
-    client_email: clientEmail,
-    private_key: privateKey,
-    token_uri: tokenUri,
-  };
+  if (parsed.type === "authorized_user") {
+    const quotaProjectId = parsed.quota_project_id;
+    if (
+      quotaProjectId !== undefined &&
+      (typeof quotaProjectId !== "string" || !quotaProjectId.trim())
+    ) {
+      throw new Error(
+        "Google authorized user quota_project_id must be a non-empty string",
+      );
+    }
+    return {
+      type: "authorized_user",
+      client_id: requiredString("client_id"),
+      client_secret: requiredString("client_secret"),
+      refresh_token: requiredString("refresh_token"),
+      ...(typeof quotaProjectId === "string"
+        ? { quota_project_id: quotaProjectId }
+        : {}),
+    };
+  }
+
+  throw new Error(
+    "Google credentials type must be service_account or authorized_user",
+  );
 }
 
 function base64Url(bytes: Uint8Array): string {
@@ -202,34 +237,45 @@ export async function createServiceAccountJwt(
 }
 
 async function fetchAccessToken(
-  credentials: ServiceAccountCredentials,
+  credentials: GoogleCredentials,
   fetcher: typeof fetch,
   now: Date,
 ): Promise<string> {
-  const assertion = await createServiceAccountJwt(credentials, now.getTime());
-  const response = await fetcher(credentials.token_uri, {
+  const tokenUri = credentials.type === "service_account"
+    ? credentials.token_uri
+    : "https://oauth2.googleapis.com/token";
+  const requestBody = credentials.type === "service_account"
+    ? new URLSearchParams({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion: await createServiceAccountJwt(credentials, now.getTime()),
+    })
+    : new URLSearchParams({
+      grant_type: "refresh_token",
+      client_id: credentials.client_id,
+      client_secret: credentials.client_secret,
+      refresh_token: credentials.refresh_token,
+    });
+  const response = await fetcher(tokenUri, {
     method: "POST",
     headers: { "content-type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
-      assertion,
-    }),
+    body: requestBody,
   });
   if (!response.ok) {
     throw new Error(
       `Google OAuth token request failed with status ${response.status}`,
     );
   }
-  const body: unknown = await response.json();
+  const responseBody: unknown = await response.json();
   if (
-    !isRecord(body) || typeof body.access_token !== "string" ||
-    !body.access_token
+    !isRecord(responseBody) ||
+    typeof responseBody.access_token !== "string" ||
+    !responseBody.access_token
   ) {
     throw new Error(
       "Google OAuth token response did not include an access token",
     );
   }
-  return body.access_token;
+  return responseBody.access_token;
 }
 
 function isoDate(date: Date): string {
@@ -250,6 +296,7 @@ function searchDateRange(
 async function fetchSearchAnalytics(
   siteUrl: string,
   accessToken: string,
+  quotaProjectId: string | undefined,
   fetcher: typeof fetch,
   now: Date,
 ): Promise<SearchAnalyticsRow[]> {
@@ -257,12 +304,16 @@ async function fetchSearchAnalytics(
   const endpoint = `https://searchconsole.googleapis.com/webmasters/v3/sites/${
     encodeURIComponent(siteUrl)
   }/searchAnalytics/query`;
+  const headers: Record<string, string> = {
+    authorization: `Bearer ${accessToken}`,
+    "content-type": "application/json",
+  };
+  if (quotaProjectId) {
+    headers["x-goog-user-project"] = quotaProjectId;
+  }
   const response = await fetcher(endpoint, {
     method: "POST",
-    headers: {
-      authorization: `Bearer ${accessToken}`,
-      "content-type": "application/json",
-    },
+    headers,
     body: JSON.stringify({
       startDate,
       endDate,
@@ -345,7 +396,7 @@ export async function analyzeGscOpportunities(
   now = new Date(),
 ): Promise<GscOpportunity[]> {
   const config = requireAnalyzerConfig(env);
-  const credentials = await loadServiceAccount(
+  const credentials = await loadGoogleCredentials(
     config.credentialsPath,
     readTextFile,
   );
@@ -353,6 +404,9 @@ export async function analyzeGscOpportunities(
   const rows = await fetchSearchAnalytics(
     config.siteUrl,
     accessToken,
+    credentials.type === "authorized_user"
+      ? credentials.quota_project_id
+      : undefined,
     fetcher,
     now,
   );


### PR DESCRIPTION
## Summary
- support authorized-user Application Default Credentials alongside service-account JWT auth
- refresh OAuth tokens without logging credentials and pass ADC quota projects to Search Console
- add focused credential validation and request-contract tests

## Validation
- Deno fmt and lint passed
- 9 analyzer tests passed
- source TypeScript and correctness lint gates passed
- production build and static prerender passed
- live read-only analysis succeeded for sc-domain:camadepilates.com (9 rows)