### PR TITLE
fix(seo): align builds and strengthen local search

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -7,7 +7,7 @@
     "dev:api": "deno run --allow-net --allow-read --allow-write --allow-env scripts/dev-api.ts",
     "dev:all": "deno run --allow-all scripts/dev-all.ts",
     "prebuild": "deno run --allow-read scripts/validate-content.ts && deno run --allow-all scripts/generate-og.cjs && deno run --allow-all scripts/generate-sitemap.cjs",
-    "build": "deno run --allow-all npm:vite build && deno run --allow-all scripts/static-prerender.cjs",
+    "build": "deno run --allow-all npm:vite build && deno run --allow-all scripts/static-prerender.cjs && deno run --allow-read scripts/verify-seo-output.cjs",
     "build:dev": "deno run --allow-all npm:vite build --mode development",
     "lint": "deno lint",
     "gsc:opportunities": "deno run --allow-env=GSC_SITE_URL,GOOGLE_APPLICATION_CREDENTIALS --allow-read --allow-net=oauth2.googleapis.com,searchconsole.googleapis.com scripts/gsc-opportunities.ts",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "dev": "vite",
     "prebuild": "node scripts/generate-og.cjs && node scripts/generate-sitemap.cjs && node scripts/generate-image-manifest.js",
-    "build": "vite build",
-    "postbuild": "node scripts/generate-image-manifest.js",
+    "build": "vite build && node scripts/static-prerender.cjs",
+    "postbuild": "node scripts/verify-seo-output.cjs && node scripts/generate-image-manifest.js",
     "build:dev": "vite build --mode development",
     "convex:dev": "convex dev",
     "convex:deploy": "convex deploy",

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,8 +1,16 @@
 /products /shop 301
+/products/ /shop 301
 /reformers/nuevas /shop/category/reformers 301
+/reformers/nuevas/ /shop/category/reformers 301
 /blog/precio-cama-de-pilates /cama-de-pilates/precio 301
+/blog/precio-cama-de-pilates/ /cama-de-pilates/precio 301
 /blog/precio-cama-de-pilates-2025 /cama-de-pilates/precio 301
+/blog/precio-cama-de-pilates-2025/ /cama-de-pilates/precio 301
 /product/reformer-casa /reformer-para-casa 301
+/product/reformer-casa/ /reformer-para-casa 301
 /product/reformer-profesional /reformer-para-estudio 301
+/product/reformer-profesional/ /reformer-para-estudio 301
 /accesorios /shop/category/accesorios 301
+/accesorios/ /shop/category/accesorios 301
 /contact /soporte 301
+/contact/ /soporte 301

--- a/scripts/static-prerender.cjs
+++ b/scripts/static-prerender.cjs
@@ -8,8 +8,12 @@ const ROOT = path.resolve(__dirname, '..');
 const DIST = path.join(ROOT, 'dist');
 const CONTENT = path.join(ROOT, 'src', 'content', 'blog');
 const PRODUCTS = path.join(ROOT, 'src', 'content', 'products.json');
+const STUDIOS = path.join(ROOT, 'src', 'data', 'studios.json');
 const SHOP_CATEGORY_SEO = JSON.parse(
   fs.readFileSync(path.join(ROOT, 'src', 'content', 'shop-category-seo.json'), 'utf8')
+);
+const STUDIO_DIRECTORY_SEO = JSON.parse(
+  fs.readFileSync(path.join(ROOT, 'src', 'content', 'studio-directory-seo.json'), 'utf8')
 );
 const REDIRECT_POST_SLUGS = new Set([
   'precio-cama-de-pilates',
@@ -382,6 +386,14 @@ function readProducts() {
   }
 }
 
+function readStudios() {
+  try {
+    return JSON.parse(fs.readFileSync(STUDIOS, 'utf8'));
+  } catch (_error) {
+    return { cities: [], studios: [] };
+  }
+}
+
 
 function renderProduct(p, origin) {
   const productSchema = {
@@ -458,15 +470,59 @@ async function main() {
   const origin = process.env.SITE_ORIGIN || 'https://camadepilates.com';
   const posts = readPosts().sort((a,b) => new Date(b.date) - new Date(a.date));
   const prods = readProducts();
+  const studioData = readStudios();
   const routeMeta = JSON.parse(fs.readFileSync(path.join(ROOT, 'src', 'content', 'route-meta.json'), 'utf8'));
   
   const certCities = [
-    { key: 'cdmx', name: 'Ciudad de México (CDMX)' },
-    { key: 'guadalajara', name: 'Guadalajara (Jalisco)' },
-    { key: 'monterrey', name: 'Monterrey (NL)' },
-    { key: 'puebla', name: 'Puebla' },
-    { key: 'queretaro', name: 'Querétaro' },
+    { key: 'cdmx', name: 'Ciudad de México (CDMX)', shortName: 'Ciudad de México', directorySlug: 'ciudad-de-mexico' },
+    { key: 'guadalajara', name: 'Guadalajara (Jalisco)', shortName: 'Guadalajara', directorySlug: 'guadalajara' },
+    { key: 'monterrey', name: 'Monterrey (NL)', shortName: 'Monterrey', directorySlug: 'monterrey' },
+    { key: 'puebla', name: 'Puebla', shortName: 'Puebla' },
+    { key: 'queretaro', name: 'Querétaro', shortName: 'Querétaro' },
   ];
+
+  // Homepage snapshot for crawlers and native Cloudflare builds.
+  {
+    const head = {
+      title: 'Cama de Pilates (Reformer) en México — Guías, Precios y Venta | CAMA Pilates',
+      description: 'Compra tu cama de Pilates Reformer en México: modelos para casa y estudio, guía de precios, dimensiones y envío desde CDMX.',
+      canonical: `${origin}/`,
+      ogImage: `${origin}/og/cama-de-pilates-venta-mexico.png`,
+      ogType: 'website',
+    };
+    const body = `
+    <main class="container mx-auto px-4 py-16">
+      <header class="max-w-4xl">
+        <p class="text-sm uppercase tracking-widest text-gray-600">Reformers para México</p>
+        <h1 class="mt-4 text-4xl md:text-6xl font-bold text-gray-900">Cama de Pilates Reformer en México</h1>
+        <p class="mt-6 text-lg text-gray-700 leading-8">Compara modelos para casa y estudio, consulta precios y encuentra guías para elegir una cama de Pilates con envío desde CDMX.</p>
+      </header>
+      <nav aria-label="Enlaces principales" class="mt-12 grid sm:grid-cols-2 lg:grid-cols-3 gap-5">
+        <a href="/shop/category/reformers" class="rounded-lg border p-6"><strong>Comprar Reformers</strong><br><span>Explora modelos y precios disponibles.</span></a>
+        <a href="/reformer-para-estudio" class="rounded-lg border p-6"><strong>Reformer para estudio</strong><br><span>Equipo profesional para uso intensivo.</span></a>
+        <a href="/reformer-para-casa" class="rounded-lg border p-6"><strong>Reformer para casa</strong><br><span>Guía para espacios residenciales.</span></a>
+        <a href="/cama-de-pilates/precio" class="rounded-lg border p-6"><strong>Precio de cama de Pilates</strong><br><span>Rangos y factores de comparación.</span></a>
+        <a href="/estudios-de-pilates" class="rounded-lg border p-6"><strong>Estudios y clases</strong><br><span>Directorio de estudios de Pilates.</span></a>
+        <a href="/certificacion-pilates" class="rounded-lg border p-6"><strong>Certificación de Pilates</strong><br><span>Formación para instructores.</span></a>
+      </nav>
+    </main>`;
+    const schema = {
+      '@context': 'https://schema.org',
+      '@type': 'ItemList',
+      name: 'Cama de Pilates Reformer — enlaces principales',
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, url: `${origin}/shop/category/reformers`, name: 'Comprar Reformers' },
+        { '@type': 'ListItem', position: 2, url: `${origin}/reformer-para-estudio`, name: 'Reformer para estudio' },
+        { '@type': 'ListItem', position: 3, url: `${origin}/reformer-para-casa`, name: 'Reformer para casa' },
+        { '@type': 'ListItem', position: 4, url: `${origin}/cama-de-pilates/precio`, name: 'Precio de cama de Pilates' },
+      ],
+    };
+    const html = baseHtml(template, head, body).replace(
+      '</head>',
+      `<script type="application/ld+json">${JSON.stringify(schema)}</script>\n</head>`,
+    );
+    writeFileForRoute('/', html);
+  }
 
   // Blog index
   const blogHead = {
@@ -739,28 +795,138 @@ async function main() {
 
   // Certification city pages (static snapshots)
   for (const c of certCities) {
+    const cityTitle = `Certificación de Pilates Reformer en ${c.shortName}`;
     const head = {
-      title: `Certificación de Pilates (Reformer) en ${c.name} | camadepilates.com`,
-      description: `Conecta con certificaciones de Pilates en ${c.name}. Reformer y Mat: requisitos, duración, costos y registro.`,
+      title: `${cityTitle} | CAMA Pilates`,
+      description: `Compara opciones de certificación de Pilates Reformer en ${c.shortName}. Revisa requisitos, duración, costos y criterios antes de solicitar fechas.`,
       canonical: `${origin}/certificacion-pilates/${c.key}`,
       ogImage: `${origin}/og/cama-de-pilates-venta-mexico.png`,
       ogType: 'website'
     };
     const certFormUrl = process.env.CERT_FORM_URL || process.env.VITE_AIRTABLE_CERT_FORM_URL || 'mailto:valery@camadepilates.com';
+    const directoryLink = c.directorySlug
+      ? `<a href="/estudios-de-pilates/${c.directorySlug}">Ver clases y estudios en ${c.shortName}</a>`
+      : '';
     const body = `
     <section class="bg-background border-b border-border">
       <div class="container mx-auto px-4 py-12">
-        <h1 class="text-3xl md:text-4xl font-bold text-foreground">Certificación de Pilates (Reformer) en ${c.name}</h1>
-        <p class="mt-4 text-lg text-muted-foreground max-w-2xl">Programas en fines de semana e intensivos. Modalidades Mat y Reformer con práctica supervisada. Cupo limitado.</p>
+        <h1 class="text-3xl md:text-4xl font-bold text-foreground">${cityTitle}</h1>
+        <p class="mt-4 text-lg text-muted-foreground max-w-2xl">Compara opciones de formación en Reformer y Mat en ${c.shortName}. Antes de inscribirte, confirma el respaldo del programa, las horas de práctica, la evaluación y el costo total.</p>
         <div class="mt-6 flex flex-wrap gap-3">
-          <a href="https://wa.me/523222787690?text=${encodeURIComponent('Hola Edelweiss, quiero inscribirme a la certificación de Pilates en ' + c.name)}" class="inline-flex items-center px-5 py-3 rounded-md bg-primary text-primary-foreground">Inscribirme en ${c.name.split(' ')[0]}</a>
+          <a href="https://wa.me/523222787690?text=${encodeURIComponent('Hola Edelweiss, quiero información sobre certificación de Pilates en ' + c.shortName)}" class="inline-flex items-center px-5 py-3 rounded-md bg-primary text-primary-foreground">Solicitar información</a>
           <a href="mailto:valery@camadepilates.com?subject=${encodeURIComponent('Certificación de Pilates - ' + c.name)}&body=${encodeURIComponent('Hola, quisiera recibir el temario, fechas y costos para la certificación de Pilates en ' + c.name + '.') }" class="inline-flex items-center px-5 py-3 rounded-md border border-foreground text-foreground">Solicitar temario</a>
           <a href="${certFormUrl}" class="inline-flex items-center px-5 py-3 rounded-md border border-foreground text-foreground">Pre-inscripción</a>
         </div>
       </div>
+    </section>
+    <section class="container mx-auto px-4 py-12">
+      <h2 class="text-2xl font-bold text-foreground">Qué comparar antes de inscribirte</h2>
+      <ul class="mt-5 space-y-3 text-muted-foreground">
+        <li>Alcance de la formación: Reformer, Mat o ruta integral.</li>
+        <li>Horas de observación, práctica y enseñanza.</li>
+        <li>Método de evaluación y organismo que respalda el certificado.</li>
+        <li>Costo total, materiales incluidos y políticas de pago.</li>
+      </ul>
+      <div class="mt-8 flex flex-wrap gap-4">
+        ${directoryLink}
+        <a href="/reformer-para-estudio">Reformers para abrir un estudio</a>
+      </div>
+      <h2 class="mt-12 text-2xl font-bold text-foreground">Preguntas frecuentes</h2>
+      <h3 class="mt-5 font-semibold">¿Una certificación de Pilates es lo mismo que tomar clases?</h3>
+      <p class="mt-2 text-muted-foreground">No. Una certificación prepara instructores; las clases son para practicar Pilates como alumno.</p>
+      <h3 class="mt-5 font-semibold">¿Cómo consulto próximas fechas y costos?</h3>
+      <p class="mt-2 text-muted-foreground">Solicita información y confirma directamente la sede, el calendario vigente, los requisitos y las políticas de pago antes de inscribirte.</p>
     </section>`;
-    const html = baseHtml(template, head, body);
+    const faq = {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: '¿Una certificación de Pilates es lo mismo que tomar clases?',
+          acceptedAnswer: { '@type': 'Answer', text: 'No. Una certificación prepara instructores; las clases son para practicar Pilates como alumno.' },
+        },
+        {
+          '@type': 'Question',
+          name: '¿Cómo consulto próximas fechas y costos?',
+          acceptedAnswer: { '@type': 'Answer', text: 'Solicita información y confirma directamente la sede, el calendario vigente, los requisitos y las políticas de pago antes de inscribirte.' },
+        },
+      ],
+    };
+    const html = baseHtml(template, head, body).replace(
+      '</head>',
+      `<script type="application/ld+json">${JSON.stringify(faq)}</script>\n</head>`,
+    );
     writeFileForRoute(`/certificacion-pilates/${c.key}`, html);
+  }
+
+  // City directory pages (static snapshots)
+  for (const c of certCities.filter(city => ['ciudad-de-mexico', 'guadalajara', 'monterrey'].includes(city.directorySlug))) {
+    const isMonterrey = c.directorySlug === 'monterrey';
+    const cityStudios = STUDIO_DIRECTORY_SEO.cities[c.directorySlug] || (studioData.studios || [])
+      .filter(studio => slugify(studio.address?.city || '') === c.directorySlug)
+      .map(studio => ({
+        name: studio.name,
+        slug: studio.slug,
+        neighborhood: studio.address?.neighborhood,
+        rating: studio.metrics?.googleRating,
+        reviewCount: studio.metrics?.googleReviewCount,
+      }));
+    const pageTitle = isMonterrey
+      ? 'Clases y Estudios de Pilates en Monterrey | CAMA Pilates'
+      : `Estudios y Clases de Pilates en ${c.shortName} | CAMA Pilates`;
+    const pageDescription = `Encuentra clases y estudios de Pilates en ${c.shortName}. Compara ubicaciones, modalidades, reseñas y opciones de Reformer.`;
+    const head = {
+      title: pageTitle,
+      description: pageDescription,
+      canonical: `${origin}/estudios-de-pilates/${c.directorySlug}`,
+      ogImage: `${origin}/og/cama-de-pilates-venta-mexico.png`,
+      ogType: 'website',
+    };
+    const studioCards = cityStudios.length
+      ? cityStudios.map(studio => `
+        <li class="rounded-lg border p-5">
+          <a href="/estudios-de-pilates/${c.directorySlug}/${htmlEscape(studio.slug)}"><strong>${htmlEscape(studio.name)}</strong></a>
+          <p class="mt-2">${htmlEscape(studio.neighborhood || c.shortName)}${studio.rating ? ` · ${htmlEscape(studio.rating)} de 5 (${htmlEscape(studio.reviewCount || 0)} reseñas)` : ''}</p>
+        </li>
+      `).join('')
+      : '<li>Consulta el directorio para comparar perfiles y opciones disponibles.</li>';
+    const body = `
+    <main class="container mx-auto px-4 py-12">
+      <nav aria-label="Migas de pan"><a href="/estudios-de-pilates">Directorio de estudios</a></nav>
+      <header class="mt-6 max-w-4xl">
+        <h1 class="text-4xl font-bold text-gray-900">${isMonterrey ? 'Clases y estudios de Pilates en Monterrey' : `Estudios y clases de Pilates en ${c.shortName}`}</h1>
+        <p class="mt-5 text-lg text-gray-700">${pageDescription}</p>
+      </header>
+      <section class="mt-10">
+        <h2 class="text-2xl font-bold text-gray-900">Opciones en ${c.shortName}</h2>
+        <ul class="mt-5 grid md:grid-cols-2 gap-5">${studioCards}</ul>
+      </section>
+      <aside class="mt-12 border-t pt-8">
+        <h2 class="text-2xl font-bold text-gray-900">¿Buscas formación o equipo profesional?</h2>
+        <p class="mt-3 text-gray-700">Las clases del directorio son para practicar Pilates. La certificación prepara instructores y el catálogo profesional reúne equipo para estudios.</p>
+        <div class="mt-5 flex flex-wrap gap-4">
+          <a href="/certificacion-pilates/${c.key}">Certificación en ${c.shortName}</a>
+          <a href="/reformer-para-estudio">Reformers para estudio</a>
+        </div>
+      </aside>
+    </main>`;
+    const itemList = {
+      '@context': 'https://schema.org',
+      '@type': 'ItemList',
+      name: `Estudios de Pilates en ${c.shortName}`,
+      itemListElement: cityStudios.map((studio, index) => ({
+        '@type': 'ListItem',
+        position: index + 1,
+        url: `${origin}/estudios-de-pilates/${c.directorySlug}/${studio.slug}`,
+        name: studio.name,
+      })),
+    };
+    const html = baseHtml(template, head, body).replace(
+      '</head>',
+      `<script type="application/ld+json">${JSON.stringify(itemList)}</script>\n</head>`,
+    );
+    writeFileForRoute(`/estudios-de-pilates/${c.directorySlug}`, html);
   }
 
   // Static landing pages. These render entirely in React, so without this they fall
@@ -788,4 +954,7 @@ async function main() {
   console.log('Static prerender complete.');
 }
 
-main().catch(console.error);
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/verify-seo-output.cjs
+++ b/scripts/verify-seo-output.cjs
@@ -1,0 +1,111 @@
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const dist = path.join(root, 'dist');
+
+function read(relativePath) {
+  const filePath = path.join(dist, relativePath);
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Missing generated SEO file: dist/${relativePath}`);
+  }
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+function requireText(content, expected, file) {
+  if (!content.includes(expected)) {
+    throw new Error(`dist/${file} is missing: ${expected}`);
+  }
+}
+
+function rejectText(content, unexpected, file) {
+  if (content.includes(unexpected)) {
+    throw new Error(`dist/${file} still contains: ${unexpected}`);
+  }
+}
+
+const home = read('index.html');
+requireText(
+  home,
+  '<title>Cama de Pilates (Reformer) en México — Guías, Precios y Venta | CAMA Pilates</title>',
+  'index.html',
+);
+requireText(home, '<link rel="canonical" href="https://camadepilates.com/">', 'index.html');
+requireText(home, '<h1', 'index.html');
+requireText(home, 'href="/shop/category/reformers"', 'index.html');
+
+const certification = read('certificacion-pilates/monterrey.html');
+requireText(
+  certification,
+  '<title>Certificación de Pilates Reformer en Monterrey | CAMA Pilates</title>',
+  'certificacion-pilates/monterrey.html',
+);
+requireText(
+  certification,
+  '<link rel="canonical" href="https://camadepilates.com/certificacion-pilates/monterrey">',
+  'certificacion-pilates/monterrey.html',
+);
+requireText(certification, 'Certificación de Pilates Reformer en Monterrey', 'certificacion-pilates/monterrey.html');
+requireText(certification, 'href="/estudios-de-pilates/monterrey"', 'certificacion-pilates/monterrey.html');
+requireText(certification, 'href="/reformer-para-estudio"', 'certificacion-pilates/monterrey.html');
+rejectText(certification, 'Keywords:', 'certificacion-pilates/monterrey.html');
+
+const monterreyDirectory = read('estudios-de-pilates/monterrey.html');
+requireText(
+  monterreyDirectory,
+  '<title>Clases y Estudios de Pilates en Monterrey | CAMA Pilates</title>',
+  'estudios-de-pilates/monterrey.html',
+);
+requireText(
+  monterreyDirectory,
+  '<link rel="canonical" href="https://camadepilates.com/estudios-de-pilates/monterrey">',
+  'estudios-de-pilates/monterrey.html',
+);
+requireText(monterreyDirectory, 'Clases y estudios de Pilates en Monterrey', 'estudios-de-pilates/monterrey.html');
+requireText(
+  monterreyDirectory,
+  'href="/certificacion-pilates/monterrey"',
+  'estudios-de-pilates/monterrey.html',
+);
+requireText(
+  monterreyDirectory,
+  'href="/estudios-de-pilates/monterrey/atoms-studio-pilates-barre-yoga"',
+  'estudios-de-pilates/monterrey.html',
+);
+requireText(monterreyDirectory, '"itemListElement":[{', 'estudios-de-pilates/monterrey.html');
+rejectText(
+  monterreyDirectory,
+  'Consulta el directorio para comparar perfiles',
+  'estudios-de-pilates/monterrey.html',
+);
+
+const studioEquipment = read('reformer-para-estudio.html');
+requireText(
+  studioEquipment,
+  '<link rel="canonical" href="https://camadepilates.com/reformer-para-estudio">',
+  'reformer-para-estudio.html',
+);
+requireText(studioEquipment, 'href="/shop/category/reformers"', 'reformer-para-estudio.html');
+
+const redirects = read('_redirects');
+for (const redirect of [
+  '/products/ /shop 301',
+  '/reformers/nuevas/ /shop/category/reformers 301',
+  '/blog/precio-cama-de-pilates/ /cama-de-pilates/precio 301',
+  '/blog/precio-cama-de-pilates-2025/ /cama-de-pilates/precio 301',
+]) {
+  requireText(redirects, redirect, '_redirects');
+}
+
+for (const obsolete of [
+  'products.html',
+  'reformers/nuevas.html',
+  'blog/precio-cama-de-pilates.html',
+  'blog/precio-cama-de-pilates-2025.html',
+]) {
+  if (fs.existsSync(path.join(dist, obsolete))) {
+    throw new Error(`Obsolete generated page remains: dist/${obsolete}`);
+  }
+}
+
+console.log('SEO output verification passed.');

--- a/src/content/studio-directory-seo.json
+++ b/src/content/studio-directory-seo.json
@@ -1,0 +1,93 @@
+{
+  "sourceCheckedAt": "2026-07-29",
+  "cities": {
+    "monterrey": [
+      {
+        "name": "Atoms Studio | Pilates, Barre & Yoga",
+        "slug": "atoms-studio-pilates-barre-yoga",
+        "neighborhood": "Fuentes del Valle",
+        "rating": 5,
+        "reviewCount": 162
+      },
+      {
+        "name": "Slowhouse Pilates",
+        "slug": "slowhouse-pilates",
+        "neighborhood": "Del Valle",
+        "rating": 4.9,
+        "reviewCount": 51
+      },
+      {
+        "name": "Pilates Now And Spa",
+        "slug": "pilates-now-and-spa",
+        "neighborhood": "Zona Residencial Chipinque",
+        "rating": 5,
+        "reviewCount": 45
+      },
+      {
+        "name": "Ambar Pilates Studio",
+        "slug": "ambar-pilates-studio",
+        "neighborhood": "Colonia del Valle",
+        "rating": 5,
+        "reviewCount": 44
+      },
+      {
+        "name": "GAIN Pilates Cardio",
+        "slug": "gain-pilates-cardio",
+        "neighborhood": "Lomas del Valle",
+        "rating": 5,
+        "reviewCount": 31
+      },
+      {
+        "name": "Iconic Pilates Studio - Pilates Reformer en Monterrey",
+        "slug": "iconic-pilates-studio-pilates-reformer-en-monterrey",
+        "neighborhood": "Tecnológico",
+        "rating": 4.9,
+        "reviewCount": 31
+      }
+    ],
+    "guadalajara": [
+      {
+        "name": "Fisiologika: Fisioterapia + Pilates + Ejercicio Terapéutico",
+        "slug": "fisiologika-fisioterapia-pilates-ejercicio-terapeutico",
+        "neighborhood": "Arcos Vallarta",
+        "rating": 5,
+        "reviewCount": 45
+      },
+      {
+        "name": "Pilates Korper Providencia",
+        "slug": "pilates-korper-providencia",
+        "neighborhood": "Providencia 3ra. Sección",
+        "rating": 4.6,
+        "reviewCount": 61
+      },
+      {
+        "name": "Soft Pilates Studio",
+        "slug": "soft-pilates-studio",
+        "neighborhood": "Providencia",
+        "rating": 4.6,
+        "reviewCount": 51
+      },
+      {
+        "name": "Studio M Yoga, Pilates, Barre",
+        "slug": "studio-m-yoga-pilates-barre",
+        "neighborhood": "San Rafael",
+        "rating": 4.9,
+        "reviewCount": 37
+      },
+      {
+        "name": "SORÉ STUDIO PILATES",
+        "slug": "sore-studio-pilates",
+        "neighborhood": "Arcos de Guadalupe",
+        "rating": 5,
+        "reviewCount": 33
+      },
+      {
+        "name": "Angels Pilates Reformer",
+        "slug": "angels-pilates-reformer",
+        "neighborhood": "Real de Valdepeñas",
+        "rating": 4.9,
+        "reviewCount": 34
+      }
+    ]
+  }
+}

--- a/src/pages/CertificacionPilatesCity.tsx
+++ b/src/pages/CertificacionPilatesCity.tsx
@@ -15,42 +15,29 @@ import {
 
 type CityKey = 'cdmx' | 'guadalajara' | 'monterrey' | 'puebla' | 'queretaro';
 
-const CITY_DATA: Record<CityKey, { name: string; variants: string[] }> = {
+const CITY_DATA: Record<CityKey, { name: string; shortName: string; directorySlug?: string }> = {
   cdmx: {
     name: 'Ciudad de México (CDMX)',
-    variants: [
-      'certificación pilates cdmx',
-      'certificación pilates reformer cdmx',
-      'certificación stott pilates cdmx',
-      'certificación pilates mexico df',
-      'certificación pilates ciudad de mexico'
-    ]
+    shortName: 'Ciudad de México',
+    directorySlug: 'ciudad-de-mexico',
   },
   guadalajara: {
     name: 'Guadalajara (Jalisco)',
-    variants: [
-      'certificación de pilates en guadalajara jalisco',
-      'certificación pilates guadalajara'
-    ]
+    shortName: 'Guadalajara',
+    directorySlug: 'guadalajara',
   },
   monterrey: {
     name: 'Monterrey (NL)',
-    variants: [
-      'certificación de pilates en monterrey',
-      'certificación pilates monterrey'
-    ]
+    shortName: 'Monterrey',
+    directorySlug: 'monterrey',
   },
   puebla: {
     name: 'Puebla',
-    variants: [
-      'certificación pilates puebla'
-    ]
+    shortName: 'Puebla',
   },
   queretaro: {
     name: 'Querétaro',
-    variants: [
-      'certificación pilates querétaro'
-    ]
+    shortName: 'Querétaro',
   }
 };
 
@@ -67,17 +54,18 @@ const CertificacionPilatesCity: React.FC = () => {
   const isCdmx = key === 'cdmx' || !CITY_DATA[key];
 
   const cityName = data.name;
+  const shortCityName = data.shortName;
   const title = isCdmx
     ? `Certificación STOTT PILATES® en ${cityName} — Programa Premium`
-    : `Certificación de Pilates (Reformer) en ${cityName}`;
+    : `Certificación de Pilates Reformer en ${shortCityName}`;
   const desc = isCdmx
     ? `Certifícate en STOTT PILATES® en ${cityName}: Intensive Reformer (125h), Mat-Plus™ y niveles avanzados en ${STOTT_VENUE.name}, sede oficial Merrithew® en Santa Fe. Fechas, costos y registro.`
-    : `Conecta con certificaciones de Pilates en ${cityName}. Reformer y Mat: requisitos, duración, costos y registro.`;
+    : `Compara opciones de certificación de Pilates Reformer en ${shortCityName}. Revisa requisitos, duración, costos y criterios antes de solicitar fechas.`;
 
   const wa = `${PRIMARY_WHATSAPP}${encodeURIComponent(
     isCdmx
       ? 'Hola, quiero inscribirme a la certificación STOTT PILATES® en CDMX'
-      : `Hola Edelweiss, quiero inscribirme a la certificación de Pilates en ${cityName}`
+      : `Hola Edelweiss, quiero información sobre certificación de Pilates en ${shortCityName}`
   )}`;
 
   const breadcrumb = {
@@ -92,14 +80,45 @@ const CertificacionPilatesCity: React.FC = () => {
   const serviceSchema = {
     '@context': 'https://schema.org',
     '@type': 'Service',
-    name: `Certificación de Pilates en ${cityName}`,
+    name: `Certificación de Pilates Reformer en ${shortCityName}`,
     areaServed: {
       '@type': 'City',
       name: cityName
     },
     provider: { '@type': 'Organization', name: 'Edelweiss / camadepilates.com', url: origin },
-    serviceType: 'Orientación e inscripción a certificaciones de Pilates (Reformer y Mat)'
+    serviceType: isCdmx
+      ? 'Inscripción a certificación de Pilates'
+      : 'Orientación sobre certificaciones de Pilates (Reformer y Mat)'
   };
+
+  const faqItems = isCdmx
+    ? []
+    : [
+        {
+          question: `¿Qué debo confirmar antes de elegir una certificación de Pilates en ${shortCityName}?`,
+          answer: 'Confirma el organismo que respalda el programa, las horas de formación y práctica, el proceso de evaluación, los materiales incluidos y el costo total.',
+        },
+        {
+          question: '¿Una certificación de Pilates es lo mismo que tomar clases?',
+          answer: 'No. Una certificación prepara instructores; las clases son para practicar Pilates como alumno. El directorio local reúne estudios para tomar clases.',
+        },
+        {
+          question: '¿Cómo consulto próximas fechas y costos?',
+          answer: 'Solicita información y confirma directamente la sede, el calendario vigente, los requisitos y las políticas de pago antes de inscribirte.',
+        },
+      ];
+
+  const faqSchema = faqItems.length
+    ? {
+        '@context': 'https://schema.org',
+        '@type': 'FAQPage',
+        mainEntity: faqItems.map(item => ({
+          '@type': 'Question',
+          name: item.question,
+          acceptedAnswer: { '@type': 'Answer', text: item.answer },
+        })),
+      }
+    : null;
 
   const courseSchemas = isCdmx
     ? STOTT_COURSES.map(course => ({
@@ -152,6 +171,9 @@ const CertificacionPilatesCity: React.FC = () => {
         <meta property="og:image" content={`${origin}${DEFAULTS.ogImage}`} />
         <script type="application/ld+json">{JSON.stringify(breadcrumb)}</script>
         <script type="application/ld+json">{JSON.stringify(serviceSchema)}</script>
+        {faqSchema && (
+          <script type="application/ld+json">{JSON.stringify(faqSchema)}</script>
+        )}
         {courseSchemas.map((schema, idx) => (
           <script key={idx} type="application/ld+json">{JSON.stringify(schema)}</script>
         ))}
@@ -159,26 +181,26 @@ const CertificacionPilatesCity: React.FC = () => {
 
       <section className="relative pt-32 pb-20 px-8 md:px-24 max-w-[1800px] mx-auto">
         <Link to="/certificacion-pilates" className="inline-flex items-center gap-2 text-xs uppercase tracking-widest text-[#5D5550] hover:text-[#2A2624] mb-8 transition-colors">
-          <ArrowLeft className="w-3 h-3" /> Back to All Locations
+          <ArrowLeft className="w-3 h-3" /> Ver todas las sedes
         </Link>
 
         <div className="grid md:grid-cols-2 gap-16 items-start">
           <div>
             <span className="block text-xs font-sans tracking-[0.3em] uppercase text-[#3E2723] mb-6">
-              {isCdmx ? 'Programa Premium · STOTT PILATES®' : 'Teacher Training'}
+              {isCdmx ? 'Programa Premium · STOTT PILATES®' : 'Formación para instructores'}
             </span>
             <h1 className="text-4xl md:text-6xl font-serif italic text-[#2A2624] leading-[0.9] mb-8">
-              {cityName}
+              {isCdmx ? cityName : title}
             </h1>
             <p className="text-lg text-[#5D5550] font-light max-w-xl leading-relaxed mb-8">
               {isCdmx
                 ? `Certificación ${STOTT_PROVIDER.method} — el "Gold Standard" de la industria — impartida por ${STOTT_PROVIDER.name} en ${STOTT_VENUE.name}, hosting oficial de Merrithew® en Santa Fe. Validez internacional en más de 100 países.`
-                : 'Programas en fines de semana e intensivos. Modalidades Mat y Reformer con práctica supervisada. Cupo limitado.'}
+                : `Compara opciones de formación en Reformer y Mat en ${shortCityName}. Antes de inscribirte, confirma el respaldo del programa, las horas de práctica, la evaluación y el costo total.`}
             </p>
 
             <div className="flex flex-wrap gap-4">
               <a href={wa} className="inline-flex items-center px-8 py-4 bg-[#2A2624] text-[#EAE8E4] rounded-full text-xs uppercase tracking-[0.2em] hover:bg-[#3E2723] transition-colors">
-                Inscribirme
+                {isCdmx ? 'Inscribirme' : 'Solicitar información'}
               </a>
               <button
                 onClick={() => setModalOpen(true)}
@@ -193,7 +215,7 @@ const CertificacionPilatesCity: React.FC = () => {
                 <MapPin className="h-4 w-4 text-[#3E2723]" /> {isCdmx ? `${STOTT_VENUE.name}, ${STOTT_VENUE.area}` : cityName}
               </div>
               <div className="flex items-center gap-3 text-sm text-[#5D5550] font-light">
-                <Calendar className="h-4 w-4 text-[#3E2723]" /> {isCdmx ? FEATURED.dates[0]?.label : 'Próximas fechas disponibles'}
+                <Calendar className="h-4 w-4 text-[#3E2723]" /> {isCdmx ? FEATURED.dates[0]?.label : 'Consulta fechas vigentes'}
               </div>
               {isCdmx && (
                 <div className="flex items-center gap-3 text-sm text-[#5D5550] font-light">
@@ -205,7 +227,7 @@ const CertificacionPilatesCity: React.FC = () => {
 
           <div className="bg-white/50 border border-[#2A2624]/10 p-8 md:p-12 rounded-sm backdrop-blur-sm">
             <h2 className="text-2xl font-serif italic text-[#2A2624] mb-8">
-              {isCdmx ? 'El Programa Incluye' : 'Program Includes'}
+              {isCdmx ? 'El Programa Incluye' : 'Qué comparar en cada programa'}
             </h2>
             {isCdmx ? (
               <ul className="space-y-4">
@@ -237,22 +259,19 @@ const CertificacionPilatesCity: React.FC = () => {
             ) : (
               <ul className="space-y-4">
                 <li className="flex items-center gap-3 text-sm text-[#5D5550] font-light">
-                  <span className="w-1.5 h-1.5 rounded-full bg-[#3E2723]"></span> Reformer y Mat
+                  <span className="w-1.5 h-1.5 rounded-full bg-[#3E2723]"></span> Alcance de la formación: Reformer, Mat o ruta integral
                 </li>
                 <li className="flex items-center gap-3 text-sm text-[#5D5550] font-light">
-                  <span className="w-1.5 h-1.5 rounded-full bg-[#3E2723]"></span> Práctica clínica y mentoreo
+                  <span className="w-1.5 h-1.5 rounded-full bg-[#3E2723]"></span> Horas de observación, práctica y enseñanza
                 </li>
                 <li className="flex items-center gap-3 text-sm text-[#5D5550] font-light">
-                  <span className="w-1.5 h-1.5 rounded-full bg-[#3E2723]"></span> Evaluación teórica y práctica
+                  <span className="w-1.5 h-1.5 rounded-full bg-[#3E2723]"></span> Método de evaluación y requisitos de aprobación
                 </li>
                 <li className="flex items-center gap-3 text-sm text-[#5D5550] font-light">
-                  <span className="w-1.5 h-1.5 rounded-full bg-[#3E2723]"></span> Bolsa de trabajo
+                  <span className="w-1.5 h-1.5 rounded-full bg-[#3E2723]"></span> Organismo que respalda el certificado
                 </li>
               </ul>
             )}
-            <p className="text-xs text-[#5D5550]/60 mt-8 pt-8 border-t border-[#2A2624]/10">
-              Keywords: {data.variants.join(', ')}
-            </p>
           </div>
         </div>
       </section>
@@ -267,7 +286,7 @@ const CertificacionPilatesCity: React.FC = () => {
       <section className="py-24 px-8 md:px-24 bg-white/40 border-t border-[#2A2624]/10">
         <div className="max-w-[1800px] mx-auto grid md:grid-cols-2 gap-16">
           <div>
-            <h2 className="text-3xl font-serif italic text-[#2A2624] mb-6">Requirements</h2>
+            <h2 className="text-3xl font-serif italic text-[#2A2624] mb-6">Requisitos</h2>
             {isCdmx ? (
               <ul className="space-y-4 text-[#5D5550] font-light">
                 <li className="flex items-start gap-3">
@@ -287,21 +306,21 @@ const CertificacionPilatesCity: React.FC = () => {
               <ul className="space-y-4 text-[#5D5550] font-light">
                 <li className="flex items-start gap-3">
                   <span className="mt-2 w-1.5 h-1.5 rounded-full bg-[#3E2723] flex-shrink-0"></span>
-                  <span>18+ y experiencia básica en Pilates o movimiento.</span>
+                  <span>Pregunta por la experiencia previa requerida en Pilates o movimiento.</span>
                 </li>
                 <li className="flex items-start gap-3">
                   <span className="mt-2 w-1.5 h-1.5 rounded-full bg-[#3E2723] flex-shrink-0"></span>
-                  <span>Horas clínicas: observación, asistencia y enseñanza.</span>
+                  <span>Confirma si las horas de observación, práctica y enseñanza están incluidas.</span>
                 </li>
                 <li className="flex items-start gap-3">
                   <span className="mt-2 w-1.5 h-1.5 rounded-full bg-[#3E2723] flex-shrink-0"></span>
-                  <span>Compromiso con práctica supervisada para Reformer.</span>
+                  <span>Solicita por escrito los criterios de evaluación y certificación.</span>
                 </li>
               </ul>
             )}
           </div>
           <div>
-            <h2 className="text-3xl font-serif italic text-[#2A2624] mb-6">Duration & Investment</h2>
+            <h2 className="text-3xl font-serif italic text-[#2A2624] mb-6">Duración e inversión</h2>
             {isCdmx ? (
               <ul className="space-y-4 text-[#5D5550] font-light">
                 <li className="flex items-start gap-3">
@@ -325,21 +344,53 @@ const CertificacionPilatesCity: React.FC = () => {
               <ul className="space-y-4 text-[#5D5550] font-light">
                 <li className="flex items-start gap-3">
                   <span className="mt-2 w-1.5 h-1.5 rounded-full bg-[#5D5550]/50 flex-shrink-0"></span>
-                  <span>Rutas de 150–450 horas según alcance.</span>
+                  <span>Compara horas lectivas, práctica personal y enseñanza supervisada por separado.</span>
                 </li>
                 <li className="flex items-start gap-3">
                   <span className="mt-2 w-1.5 h-1.5 rounded-full bg-[#5D5550]/50 flex-shrink-0"></span>
-                  <span>Rangos orientativos: $8,000–$25,000 MXN (módulos) y $30,000–$80,000 MXN (programas profesionales).</span>
+                  <span>Confirma si manuales, evaluaciones, reposiciones e impuestos están incluidos en el precio.</span>
                 </li>
                 <li className="flex items-start gap-3">
                   <span className="mt-2 w-1.5 h-1.5 rounded-full bg-[#5D5550]/50 flex-shrink-0"></span>
-                  <span>Planes de pago y descuentos por pronto pago (consulta sedes).</span>
+                  <span>Consulta directamente las fechas, costos y políticas de pago vigentes.</span>
                 </li>
               </ul>
             )}
           </div>
         </div>
       </section>
+
+      {!isCdmx && (
+        <section className="py-24 px-8 md:px-24 border-t border-[#2A2624]/10">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-3xl font-serif italic text-[#2A2624] mb-10">Preguntas frecuentes</h2>
+            <div className="space-y-8">
+              {faqItems.map(item => (
+                <article key={item.question}>
+                  <h3 className="text-lg font-medium text-[#2A2624]">{item.question}</h3>
+                  <p className="mt-3 text-[#5D5550] font-light leading-relaxed">{item.answer}</p>
+                </article>
+              ))}
+            </div>
+            <div className="mt-12 flex flex-wrap gap-4">
+              {data.directorySlug && (
+                <Link
+                  to={`/estudios-de-pilates/${data.directorySlug}`}
+                  className="inline-flex items-center px-6 py-3 border border-[#2A2624]/20 rounded-full text-xs uppercase tracking-[0.15em] text-[#2A2624] hover:bg-white transition-colors"
+                >
+                  Ver clases y estudios en {shortCityName}
+                </Link>
+              )}
+              <Link
+                to="/reformer-para-estudio"
+                className="inline-flex items-center px-6 py-3 border border-[#2A2624]/20 rounded-full text-xs uppercase tracking-[0.15em] text-[#2A2624] hover:bg-white transition-colors"
+              >
+                Reformers para abrir un estudio
+              </Link>
+            </div>
+          </div>
+        </section>
+      )}
 
       <PreRegistrationModal
         isOpen={modalOpen}

--- a/src/pages/IndexAuthority.tsx
+++ b/src/pages/IndexAuthority.tsx
@@ -152,11 +152,13 @@ const IndexAuthority: React.FC = () => {
               className="flex flex-col lg:flex-row lg:items-end justify-between gap-8"
             >
               <div className="max-w-4xl">
-                {/* Brand/Logo Text styled as 'ivan.codes' example */}
-                <h1 className="font-serif text-6xl md:text-8xl lg:text-[7rem] leading-[0.9] tracking-tighter text-[#2A2624] mb-6">
+                <div className="font-serif text-6xl md:text-8xl lg:text-[7rem] leading-[0.9] tracking-tighter text-[#2A2624] mb-6">
                   Edelweiss<span className="text-[#EB4C42]">.</span>
+                </div>
+                <h1 className="font-sans text-2xl md:text-3xl text-[#2A2624] max-w-3xl leading-tight font-medium tracking-tight">
+                  Cama de Pilates Reformer en México
                 </h1>
-                <p className="font-sans text-xl md:text-2xl text-[#5D5550] max-w-2xl leading-relaxed font-normal tracking-tight">
+                <p className="mt-4 font-sans text-xl md:text-2xl text-[#5D5550] max-w-2xl leading-relaxed font-normal tracking-tight">
                   Encuentra más de <span className="text-[#EB4C42] font-medium">900 Estudios</span> de Pilates, <span className="text-[#EB4C42] font-medium">Cursos</span>, <span className="text-[#EB4C42] font-medium">Instructores</span> y <span className="text-[#EB4C42] font-medium">Reformers</span>.
                   La plataforma de Pilates más grande de México.
                 </p>

--- a/src/pages/estudios-de-pilates/CityDirectory.tsx
+++ b/src/pages/estudios-de-pilates/CityDirectory.tsx
@@ -27,7 +27,7 @@ import {
 } from "@/components/ui/sheet";
 import { citySlug } from "@/utils/slug";
 import LuxuryLayout from "@/components/layout/LuxuryLayout";
-import { generateCityDirectorySchema } from "@/lib/seo";
+import { DEFAULTS, generateCityDirectorySchema, getOrigin } from "@/lib/seo";
 import { hasConvex } from "@/lib/convexProvider";
 import localData from "@/data/studios.json";
 
@@ -48,6 +48,32 @@ const cityNameMap: Record<string, string> = {
   guadalajara: "Guadalajara",
 };
 
+const certificationCityMap: Record<string, string> = {
+  "ciudad-de-mexico": "cdmx",
+  guadalajara: "guadalajara",
+  monterrey: "monterrey",
+  puebla: "puebla",
+  queretaro: "queretaro",
+};
+
+const cityCenters: Record<string, { lat: number; lng: number }> = {
+  "ciudad-de-mexico": { lat: 19.4326, lng: -99.1332 },
+  guadalajara: { lat: 20.6597, lng: -103.3496 },
+  monterrey: { lat: 25.6866, lng: -100.3161 },
+};
+
+function distanceKm(from: { lat: number; lng: number }, to: { lat: number; lng: number }) {
+  const radians = Math.PI / 180;
+  const latDelta = (to.lat - from.lat) * radians;
+  const lngDelta = (to.lng - from.lng) * radians;
+  const value =
+    Math.sin(latDelta / 2) ** 2 +
+    Math.cos(from.lat * radians) *
+      Math.cos(to.lat * radians) *
+      Math.sin(lngDelta / 2) ** 2;
+  return 12742 * Math.asin(Math.sqrt(value));
+}
+
 const CityDirectory: React.FC = () => {
   const { city } = useParams<{ city: string }>();
   const navigate = useNavigate();
@@ -55,6 +81,10 @@ const CityDirectory: React.FC = () => {
   // Get city name from URL slug
   const cityName = city ? cityNameMap[city.toLowerCase()] || city : "";
   const normalizedSlug = cityName ? citySlug(cityName) : city || "";
+  const origin = getOrigin();
+  const isMonterrey = normalizedSlug === "monterrey";
+  const certificationCity = certificationCityMap[normalizedSlug];
+  const mapCenter = cityCenters[normalizedSlug] || cityCenters["ciudad-de-mexico"];
 
   useEffect(() => {
     if (city && normalizedSlug && city !== normalizedSlug) {
@@ -72,15 +102,24 @@ const CityDirectory: React.FC = () => {
     () => localData.cities.find((candidate) => candidate.slug === normalizedSlug),
     [normalizedSlug]
   );
+  const validRemoteStudios = useMemo(() => {
+    if (!Array.isArray(remoteStudios)) return [];
+    const center = cityCenters[normalizedSlug];
+    if (!center) return remoteStudios;
+    return remoteStudios.filter((studio) => {
+      const coordinates = studio.address?.coordinates;
+      return coordinates && distanceKm(center, coordinates) <= 75;
+    });
+  }, [normalizedSlug, remoteStudios]);
   const studios = useMemo(() => {
-    if (!Array.isArray(remoteStudios) || remoteStudios.length === 0) {
+    if (validRemoteStudios.length === 0) {
       return fallbackStudios;
     }
 
-    const remoteKeys = new Set(remoteStudios.map((studio) => studio.slug));
+    const remoteKeys = new Set(validRemoteStudios.map((studio) => studio.slug));
     const missingFallbackStudios = fallbackStudios.filter((studio) => !remoteKeys.has(studio.slug));
-    return [...remoteStudios, ...missingFallbackStudios];
-  }, [fallbackStudios, remoteStudios]);
+    return [...validRemoteStudios, ...missingFallbackStudios];
+  }, [fallbackStudios, validRemoteStudios]);
   const cityData = remoteCityData || fallbackCityData;
 
   // UI state for filters/search
@@ -199,8 +238,12 @@ const CityDirectory: React.FC = () => {
   };
 
   // SEO
-  const pageTitle = `Estudios de Pilates en ${cityName} - ${filteredStudios.length} Opciones`;
-  const pageDescription = `Encuentra los mejores estudios de Pilates en ${cityName}. Compara ${filteredStudios.length} estudios con reseñas, precios y ubicaciones.`;
+  const pageTitle = isMonterrey
+    ? `Clases y Estudios de Pilates en Monterrey | ${DEFAULTS.siteName}`
+    : `Estudios y Clases de Pilates en ${cityName} | ${DEFAULTS.siteName}`;
+  const pageDescription = isMonterrey
+    ? "Encuentra clases y estudios de Pilates en Monterrey. Compara ubicaciones, modalidades, reseñas y opciones de Reformer."
+    : `Encuentra clases y estudios de Pilates en ${cityName}. Compara ubicaciones, modalidades, reseñas y opciones de Reformer.`;
 
   const cityDirectorySchema = generateCityDirectorySchema({
     cityName,
@@ -220,6 +263,12 @@ const CityDirectory: React.FC = () => {
       <Helmet>
         <title>{pageTitle}</title>
         <meta name="description" content={pageDescription} />
+        <link rel="canonical" href={`${origin}/estudios-de-pilates/${normalizedSlug}`} />
+        <meta property="og:title" content={pageTitle} />
+        <meta property="og:description" content={pageDescription} />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content={`${origin}/estudios-de-pilates/${normalizedSlug}`} />
+        <meta property="og:image" content={`${origin}${DEFAULTS.ogImage}`} />
         <script type="application/ld+json">
           {JSON.stringify(cityDirectorySchema)}
         </script>
@@ -236,7 +285,7 @@ const CityDirectory: React.FC = () => {
 
         <div className="text-center mb-16">
           <h1 className="text-5xl md:text-7xl font-serif italic text-[#2A2624] mb-8">
-            {cityName}
+            {isMonterrey ? "Clases y estudios de Pilates en Monterrey" : `Estudios y clases de Pilates en ${cityName}`}
           </h1>
           <p className="text-lg text-[#5D5550] mb-6">
             Encuentra el estudio perfecto para tu práctica de Pilates.
@@ -373,7 +422,7 @@ const CityDirectory: React.FC = () => {
               {viewTab === "map" && (
                 <StudioMap
                   studios={filteredStudios}
-                  center={{ lat: 19.4326, lng: -99.1332 }}
+                  center={mapCenter}
                   height="700px"
                   showControls={true}
                   onStudioClick={(studio) => {
@@ -382,6 +431,31 @@ const CityDirectory: React.FC = () => {
                 />
               )}
             </Tabs>
+          </div>
+        </div>
+      </section>
+
+      <section className="px-8 md:px-24 pb-24">
+        <div className="max-w-4xl mx-auto border-t border-[#2A2624]/10 pt-12">
+          <h2 className="text-2xl font-serif italic text-[#2A2624]">¿Buscas formación o equipo profesional?</h2>
+          <p className="mt-3 text-[#5D5550] font-light">
+            Las clases del directorio son para practicar Pilates. La certificación prepara instructores y el catálogo profesional reúne equipo para estudios.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-4">
+            {certificationCity && (
+              <Link
+                to={`/certificacion-pilates/${certificationCity}`}
+                className="inline-flex items-center px-6 py-3 border border-[#2A2624]/20 rounded-full text-xs uppercase tracking-[0.15em] text-[#2A2624] hover:bg-white transition-colors"
+              >
+                Certificación en {cityName}
+              </Link>
+            )}
+            <Link
+              to="/reformer-para-estudio"
+              className="inline-flex items-center px-6 py-3 border border-[#2A2624]/20 rounded-full text-xs uppercase tracking-[0.15em] text-[#2A2624] hover:bg-white transition-colors"
+            >
+              Reformers para estudio
+            </Link>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- align npm and Deno production builds so Cloudflare always deploys verified prerendered SEO HTML
- add homepage, certification, and city-directory snapshots with canonical metadata, structured data, and internal links
- separate Monterrey certification and classes intent, filter cross-city listings, and add trailing-slash redirects

## Validation
- source TypeScript gate and correctness lint gate
- 9 Search Console analyzer tests
- npm and Deno production builds with exact critical-output parity
- fail-loud SEO output verifier under Node and Deno
- desktop and mobile browser QA
- independent review: approved